### PR TITLE
Replace linux placeholders

### DIFF
--- a/unattended_upgrades_repos.py
+++ b/unattended_upgrades_repos.py
@@ -1,4 +1,4 @@
-import os, re, pdb
+import os, re, pdb, platform
 from pprint import pprint
 
 ## Get the repos
@@ -41,7 +41,10 @@ with open('/etc/apt/apt.conf.d/50unattended-upgrades', 'r') as f:
   read_data = f.read()
   # get everything before first };
   raw_data = re.findall('[.\s\S]*};', read_data)
-  repos_already_present=re.findall('".*:.*";', raw_data[0])
+  # replace linux placeholders
+  distro_id, _, distro_codename = platform.linux_distribution()
+  clean_data = raw_data[0].replace("${distro_id}",distro_id).replace("${distro_codename}",distro_codename)
+  repos_already_present = re.findall('".*:.*";', clean_data)
 
 
 repos_to_add = [repo for repo in repos_to_add if repo not in repos_already_present]


### PR DESCRIPTION
Fixes Issue #2.
- Uses platform library in linux and does a simple replace in the string.